### PR TITLE
Fix opactiy: Added class "in" to active tab.

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -124,7 +124,7 @@
         tabId = tabId.substring(0, tabId.length - 9); //remove -collapse from identifier
 
         event.data.tabCollapse.getTabContentElement().find('.active').removeClass('active');
-        $('#' + tabId).addClass('active');
+        $('#' + tabId).addClass('active in');
     }
 
     TabCollapse.prototype.showAccordion = function(){


### PR DESCRIPTION
In my case after switching from collapse to tabs was active tab invisible. I use "fade" feature. In CSS is

``` css
.fade {
    opacity: 0;
}
.fade.in {
    opacity: 1;
}
```

So I added class "in" and it works.
